### PR TITLE
docs: improved README with architecture, prerequisites and learning order

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,87 @@
 
 ## 🛠️ Tech Stack
 
-- **Frontend**: Next.js, React, Tailwind CSS, Framer Motion, Lucide Icons, Recharts
-- **Backend/Desktop Platform**: Tauri, Rust
-- **Machine Learning**: Python, PyTorch, Torchvision, Scikit-learn, Pandas, Matplotlib, Seaborn
+| Layer | Technologies |
+|---|---|
+| **Frontend** | Next.js, React, Tailwind CSS, Framer Motion, Lucide Icons, Recharts |
+| **Desktop Platform** | Tauri v2, Rust |
+| **Machine Learning** | Python, PyTorch, Torchvision, Scikit-learn, Pandas, Matplotlib, Seaborn |
+
+---
+
+## 🏗️ Architecture
+
+EPOQ has **three distinct layers** that communicate with each other:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│                    DESKTOP APP WINDOW                    │
+│          (Powered by Tauri — like Electron but tiny)     │
+│                                                          │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │            Next.js Frontend  (UI Layer)          │   │
+│  │   React components + Tailwind + Recharts charts  │   │
+│  │   Framer Motion animations + Lucide Icons        │   │
+│  └──────────────────┬─────────────────────────────-─┘   │
+│                     │  Tauri Commands (IPC bridge)       │
+│  ┌──────────────────▼───────────────────────────────┐   │
+│  │            Rust Core  (Tauri Backend)             │   │
+│  │   Manages filesystem, dialogs, OS integrations   │   │
+│  │   Spawns Python subprocess, streams logs to UI   │   │
+│  └──────────────────┬─────────────────────────────-─┘   │
+│                     │  subprocess / stdout stream        │
+│  ┌──────────────────▼───────────────────────────────┐   │
+│  │         Python + PyTorch  (ML Worker)             │   │
+│  │   script.py        — training loop               │   │
+│  │   model_factory.py — loads ResNet, EVA02, DCN    │   │
+│  │   scikit-learn     — metrics, confusion matrix   │   │
+│  └──────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────┘
+```
+
+### How it flows
+
+1. **You click "Start Training"** in the Next.js UI.
+2. **Tauri (Rust)** receives that event, opens file dialogs, and spawns a Python subprocess.
+3. **Python** runs the real PyTorch training loop and prints logs/metrics to stdout.
+4. **Rust** streams that stdout back to the frontend in real time.
+5. **The UI** displays live loss/accuracy charts and logs as training progresses.
+
+### Why this architecture?
+
+| Decision | Reasoning |
+|---|---|
+| **Tauri over Electron** | Tauri uses the OS's native WebView + Rust backend, making the binary ~10x smaller than Electron with better performance. |
+| **Rust as the bridge** | Safe, fast, and excellent for system operations — launching subprocesses, reading the filesystem, opening native dialogs. |
+| **Python for ML** | The entire ML ecosystem (PyTorch, scikit-learn, etc.) is Python-first. There is no comparable alternative. |
+| **Next.js for UI** | The UI is just a web page, so frontend developers can contribute without learning any desktop-specific framework. |
+
+---
+
+## 📁 Project Structure
+
+```
+EPOQ/
+└── image-trainer/              # The full desktop application
+    ├── src/app/                # Next.js pages (UI screens)
+    ├── src-tauri/              # Rust + Tauri backend
+    │   ├── src/                # Rust source (main.rs)
+    │   ├── python_backend/     # Python ML scripts
+    │   │   ├── script.py           # Main training loop
+    │   │   ├── model_factory.py    # Model architecture loader
+    │   │   ├── tabular_processor.py
+    │   │   └── check_gpu.py
+    │   └── tauri.conf.json     # Tauri app configuration
+    └── public/                 # Static assets
+```
 
 ---
 
 ## 🚀 Prerequisites
 
-Before you begin, ensure you have the following installed on your system:
+### System Requirements
+
+Before you begin, ensure you have the following installed:
 
 1. **[Node.js](https://nodejs.org/)** (v18+)
 2. **[Rust](https://rustup.rs/)** (Required for Tauri builds)
@@ -47,6 +119,79 @@ Before you begin, ensure you have the following installed on your system:
    ```bash
    pip install torch torchvision pandas scikit-learn matplotlib seaborn
    ```
+
+### Knowledge Prerequisites
+
+You don't need to know all of this before you start — but here's what's useful to learn for each layer of the project:
+
+| Layer | Concept to know | Why it matters |
+|---|---|---|
+| **UI (Frontend)** | HTML & CSS basics | Foundation for any web work |
+| **UI (Frontend)** | JavaScript / TypeScript | Language of the frontend |
+| **UI (Frontend)** | React (components, hooks, state) | All UI components are built in React |
+| **UI (Frontend)** | Next.js App Router | How pages and routing are structured |
+| **UI (Frontend)** | TailwindCSS | How styling is done in this project |
+| **Desktop Bridge** | What Tauri/IPC is (conceptual) | How the UI talks to Rust |
+| **Desktop Bridge** | Rust basics *(optional)* | Only needed for Tauri backend changes |
+| **ML Worker** | Python basics | The ML scripts are all Python |
+| **ML Worker** | PyTorch basics | Training loops, models, tensors |
+| **ML Worker** | Basic ML concepts (epochs, loss, accuracy) | Understanding what the app is doing |
+
+> 💡 **Tip:** If you're new to the project, start with the **UI layer** — it's the most approachable and doesn't require knowing Rust or Python.
+
+---
+
+## 📚 Suggested Learning Order
+
+If you're starting from scratch, here's the most efficient path to being able to contribute:
+
+```
+Step 1 — Web Fundamentals (1–2 weeks)
+   HTML + CSS basics
+   → Resource: MDN Web Docs (developer.mozilla.org)
+
+Step 2 — JavaScript ES6+ (2–4 weeks)
+   Arrow functions, async/await, modules, array methods
+   → Resource: javascript.info
+
+Step 3 — TypeScript Basics (1 week)
+   Types, interfaces, generics
+   → Resource: TypeScript Handbook (typescriptlang.org/docs)
+
+Step 4 — React (2–3 weeks)
+   Components, props, state, hooks (useState, useEffect)
+   → Resource: react.dev (official docs)
+
+Step 5 — Next.js (1 week)
+   App Router, file-based routing, layouts
+   → Resource: nextjs.org/docs
+
+Step 6 — TailwindCSS (2–3 days)
+   Utility classes, responsive design
+   → Resource: tailwindcss.com/docs
+
+        ✅ You can now contribute to the UI layer!
+
+Step 7 — Python Basics (2–3 weeks, if not already known)
+   Functions, classes, file I/O
+   → Resource: python.org/about/gettingstarted
+
+Step 8 — PyTorch Basics (3–4 weeks)
+   Tensors, datasets, training loops, model loading
+   → Resource: pytorch.org/tutorials
+
+Step 9 — ML Fundamentals (ongoing)
+   Loss functions, evaluation metrics, confusion matrices
+   → Resource: fast.ai (free, practical course)
+
+        ✅ You can now contribute to the ML worker layer!
+
+Step 10 — Rust Basics (optional, 2–4 weeks)
+   Ownership, structs, enums, subprocess management
+   → Resource: doc.rust-lang.org/book (The Rust Book)
+
+        ✅ You can now contribute to the Tauri backend layer!
+```
 
 ---
 
@@ -83,16 +228,6 @@ npm run tauri build
 ```
 
 Once the build is complete, you can find the executable in `src-tauri/target/release/`.
-
----
-
-## 🧩 Architecture
-
-The application marries web technologies with native system capabilities:
-
-1. **Next.js Frontend**: Provides a highly responsive, modern UI styled with Tailwind CSS.
-2. **Tauri Core**: Written in Rust, it acts as the bridge, managing system menus, dialogs, and native operations.
-3. **Python Worker Runtime**: Tauri spawns a Python subprocess (`python_backend/script.py`) to execute PyTorch training scripts securely and stream the stdout/stderr back to the UI for live tracking.
 
 ---
 


### PR DESCRIPTION
This PR improves the EPOQ README.md to make it significantly more contributor-friendly.

Changes:

🏗️ Simplified architecture section — Added an ASCII diagram showing the 3-layer flow: Next.js UI → Rust/Tauri bridge → Python/PyTorch ML worker, plus an explanation of how data flows during training
📊 Architecture rationale table — Explains why each technology was chosen (Tauri vs Electron, Rust as bridge, Python for ML)
📁 Project structure tree — Shows where to find each layer's code
📚 Knowledge prerequisites table — Broken down by layer (UI / Desktop Bridge / ML Worker) so contributors know exactly what to learn for the part they want to work on
🗺️ 10-step suggested learning order — A clear path from complete beginner to full-stack contributor, with resource links for each step