### PR TITLE
chore: Add Makefile with shortcuts for common development tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,13 @@ help:
 	@echo ""
 	@echo "  EPOQ — Available Commands"
 	@echo "  ========================="
-	@echo "  make install      Install Node.js dependencies"
-	@echo "  make dev          Start the development server"
-	@echo "  make build        Build the production desktop app"
-	@echo "  make clean        Remove build artifacts"
+	@echo "  make install         Install Node.js dependencies"
+	@echo "  make python-install  Install Python ML dependencies"
+	@echo "  make setup           Run full setup (Node + Python)"
+	@echo "  make dev             Start the development server"
+	@echo "  make build           Build the production desktop app"
+	@echo "  make lint            Run the frontend linter"
+	@echo "  make clean           Remove build artifacts"
 	@echo ""
 
 install:
@@ -33,3 +36,14 @@ clean:
 	cd image-trainer && rm -rf .next node_modules src-tauri/target
 	@echo "✅ Clean complete."
 
+python-install:
+	@echo "🐍 Installing Python ML dependencies..."
+	pip install torch torchvision pandas scikit-learn matplotlib seaborn
+	@echo "✅ Python dependencies installed."
+
+lint:
+	@echo "🔍 Running linter..."
+	cd image-trainer && npm run lint
+
+setup: install python-install
+	@echo "✅ Full setup complete! Run 'make dev' to start."


### PR DESCRIPTION
## What this PR does
Adds a `Makefile` at the repository root to simplify common 
developer tasks with easy-to-remember commands.

## New commands available
- `make setup`           — Full one-command project setup
- `make install`         — Install Node dependencies  
- `make python-install`  — Install Python ML dependencies
- `make dev`             — Start development server
- `make build`           — Build production app
- `make lint`            — Run linter
- `make clean`           — Remove build artifacts
- `make help`            — Show all commands

## Testing
Run `make help` from the project root to verify all commands are listed.